### PR TITLE
Bump base version for ghc 9.2 Compatibility

### DIFF
--- a/flow.cabal
+++ b/flow.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 library
   build-depends:
-    base >= 4.13.0 && < 4.16
+    base >= 4.13.0 && < 4.17
   default-language: Haskell2010
   exposed-modules: Flow
   ghc-options:


### PR DESCRIPTION
It builds with `resolver: ghc-9.2` 😃